### PR TITLE
Only pip upgrade dependencies if needed

### DIFF
--- a/update.cmd
+++ b/update.cmd
@@ -2,5 +2,5 @@
 ECHO "updating qcodes" nul
 CALL activate qcodes-qdev-master > nul
 CALL conda upgrade --all -y
-CALL pip install -U https://github.com/qdev-dk/Qcodes/archive/master.zip 
+CALL pip install -U https://github.com/qdev-dk/Qcodes/archive/master.zip --upgrade-strategy only-if-needed
 pause


### PR DESCRIPTION
prevent pip from unconditionally upgrading dependencies. 
I.e conda currently installes setuptools 27.x and a dependency of 
qcodes depends on setuptools so pip install qcodes upgrades setuptools 
which breaks because it is installed from conda.